### PR TITLE
add gsoc card to the home page

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -250,7 +250,7 @@ Page: Homepage
 
     .box-02 .col {position:relative; float:left; width:300px; padding-bottom:17px; margin-bottom:-6px; z-index:2; background-position:100% 100%; background-repeat:no-repeat;}
     .box-02 .col.left {background-image:url("../design/image-01.jpg");}
-    /*.box-02 .col.center {background-image:url("../design/soc-logo-190.png");}*/
+    .box-02 .col.center {background-image:url("../design/soc-logo-190.png");}
     .box-02 .col .in {min-height:180px; height:auto;}
     .box-02 .col h2 {margin:0; font-size:100%; font-weight:bold; text-transform:uppercase;}
     .box-02 .col p {margin:15px 0;}

--- a/templates/home.html
+++ b/templates/home.html
@@ -29,11 +29,15 @@
 
         <div class="col center">
             <div class="in">
-                <h2>Shogun talks</h2>
+                <h2>Google Summer of Code 2015</h2>
                 <p align="justify">
-                    SHOGUN was presented in July at the <a href="https://ep2014.europython.eu/en/schedule/sessions/103/">Europython conference</a> in Berlin and in August at the <a href="http://hunch.net/~nyoml/">Open Machine Learning Workshop</a> in New York, both times by Heiko Strathmann. These talks are of interest both to people that do not know about SHOGUN and are interested in using it or just getting an introduction, as well as for people with prior experience using SHOGUN.
+                    <strong>We have applied as a mentoring org.<br></strong>
+                    Our list of project ideas this year is full of exciting and fun
+                    projects. There is also a new guide for prospective students. Let's now keep
+                    our fingers crossed until accepted mentoring orgs are announced!
                 </p>
             </div>
+            <p class="nom"><a href="/page/Events/gsoc2014/"><img src="/static/design/btn-more.gif" alt="More" /></a></p>
         </div>
 
         <div class="col right">


### PR DESCRIPTION
This adds gsoc back to the main page. @karlnapf what should the `more` button link to?
